### PR TITLE
feat: Add jsdom unit tests

### DIFF
--- a/docs/brainstorms/2026-01-24-unit-testing-brainstorm.md
+++ b/docs/brainstorms/2026-01-24-unit-testing-brainstorm.md
@@ -1,0 +1,38 @@
+# Unit Testing Strategy Brainstorm
+
+**Date:** 2026-01-24
+
+## What We're Building
+
+Add jsdom-based unit tests alongside existing Vitest browser tests for testing utility functions and pure logic.
+
+## Why This Approach
+
+- **Speed:** jsdom tests run in ~10ms vs browser tests in ~100-500ms
+- **Simplicity:** Pure functions need no mocking or browser context
+- **Complementary:** Browser tests for components, unit tests for logic
+- **YAGNI:** Start with utilities only—expand later if needed
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Test targets | Utility functions only | Highest value-to-effort; stores tested via browser tests |
+| Config approach | Separate `vitest.config.ts` | Simpler than workspaces, explicit separation |
+| File location | Co-located (`*.test.ts`) | Easy to find, matches browser test pattern |
+| Test naming | `*.test.ts` (unit) vs `*.browser.test.ts` | Clear distinction from browser tests |
+
+## Implementation Outline
+
+1. Create `vitest.config.ts` with jsdom environment
+2. Create setup file `src/test/vitest.setup.ts`
+3. Add `test:unit` script to package.json
+4. Add example test for existing utility
+
+## Open Questions
+
+None—straightforward implementation.
+
+## Next Steps
+
+Run `/workflows:plan` to generate implementation plan.

--- a/docs/plans/2026-01-24-feat-add-jsdom-unit-tests-plan.md
+++ b/docs/plans/2026-01-24-feat-add-jsdom-unit-tests-plan.md
@@ -1,0 +1,129 @@
+---
+title: Add jsdom Unit Tests
+type: feat
+date: 2026-01-24
+---
+
+# feat: Add jsdom Unit Tests
+
+Add Vitest unit tests (jsdom environment) alongside existing browser tests for testing utility functions and pure logic.
+
+## Overview
+
+Currently, the project only has browser-mode tests (`*.browser.test.tsx`). This adds a faster jsdom-based test environment for pure functions and utilities.
+
+**Why:** jsdom tests run ~10-50x faster than browser tests. Pure functions don't need real browser context.
+
+## Acceptance Criteria
+
+- [x] `vitest.config.ts` created with jsdom environment
+- [x] `src/test/vitest.setup.ts` created
+- [x] `test:unit` script added to package.json
+- [x] Example test for `canModifyProduct.ts` utility
+- [x] Unit tests run independently from browser tests
+
+## Implementation
+
+### 1. Create `vitest.config.ts`
+
+```ts
+// vitest.config.ts
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+    plugins: [tsconfigPaths()],
+    test: {
+        include: ["src/**/*.test.{ts,tsx}"],
+        exclude: ["src/**/*.browser.test.{ts,tsx}"],
+        environment: "jsdom",
+        setupFiles: ["src/test/vitest.setup.ts"],
+    },
+});
+```
+
+**Note:** Standalone config (not merged with vite.config) to avoid TanStack/Tailwind plugin overhead.
+
+### 2. Create `src/test/vitest.setup.ts`
+
+```ts
+// src/test/vitest.setup.ts
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+    cleanup();
+});
+```
+
+Minimal setup—just cleanup. Add matchers later if needed.
+
+### 3. Add script to `package.json`
+
+```json
+{
+    "scripts": {
+        "test:unit": "vitest run --config vitest.config.ts"
+    }
+}
+```
+
+### 4. Create example test: `src/utils/canModifyProduct.test.ts`
+
+```ts
+// src/utils/canModifyProduct.test.ts
+import { describe, it, expect } from "vitest";
+import { canModifyProduct, isActionDisabled } from "./canModifyProduct";
+
+describe("canModifyProduct", () => {
+    it("returns true when user is seller", () => {
+        const user = { id: "user-1", role: "seller" };
+        expect(canModifyProduct(user, "user-1")).toBe(true);
+    });
+
+    it("returns false when user is not seller", () => {
+        const user = { id: "user-1", role: "seller" };
+        expect(canModifyProduct(user, "user-2")).toBe(false);
+    });
+
+    it("returns false when user is null", () => {
+        expect(canModifyProduct(null, "user-1")).toBe(false);
+    });
+});
+
+describe("isActionDisabled", () => {
+    // TODO: User implements based on business logic understanding
+});
+```
+
+## File Structure
+
+```
+vitest.config.ts          <- NEW (unit tests)
+vitest.browser.config.ts  <- EXISTS (browser tests)
+src/
+  test/
+    vitest.setup.ts       <- NEW (unit setup)
+    vitest-browser.setup.ts <- EXISTS
+  utils/
+    canModifyProduct.ts
+    canModifyProduct.test.ts <- NEW (example)
+```
+
+## Test Commands After Implementation
+
+| Command | Purpose |
+|---------|---------|
+| `bun run test` | Existing default (unchanged) |
+| `bun run test:unit` | Run jsdom unit tests |
+| `bun run test:browser` | Run Playwright browser tests |
+
+## Dependencies
+
+No new dependencies—jsdom (`^27.0.0`) already installed.
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-01-24-unit-testing-brainstorm.md`
+- Existing browser config: `vitest.browser.config.ts`
+- Test target: `src/utils/canModifyProduct.ts`

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"preview": "bun --bun vite preview",
 		"deploy": "vite build",
 		"test": "vitest run",
+		"test:unit": "vitest run --config vitest.config.ts",
 		"test:browser": "vitest run --config vitest.browser.config.ts",
 		"test:browser:headed": "vitest run --config vitest.browser.config.ts --browser.headless=false",
 		"format": "biome format",

--- a/src/test/vitest.setup.ts
+++ b/src/test/vitest.setup.ts
@@ -1,0 +1,6 @@
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+	cleanup();
+});

--- a/src/utils/canModifyProduct.test.ts
+++ b/src/utils/canModifyProduct.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { canModifyProduct, isActionDisabled } from "./canModifyProduct";
+
+describe("canModifyProduct", () => {
+	it("returns true when user is ADMIN", () => {
+		const user = { id: "admin-1", role: "ADMIN" } as const;
+		expect(canModifyProduct(user as never, "seller-1")).toBe(true);
+	});
+
+	it("returns true when SELLER owns the product", () => {
+		const user = { id: "seller-1", role: "SELLER" } as const;
+		expect(canModifyProduct(user as never, "seller-1")).toBe(true);
+	});
+
+	it("returns false when SELLER does not own the product", () => {
+		const user = { id: "seller-1", role: "SELLER" } as const;
+		expect(canModifyProduct(user as never, "seller-2")).toBe(false);
+	});
+
+	it("returns false when user is CUSTOMER", () => {
+		const user = { id: "customer-1", role: "CUSTOMER" } as const;
+		expect(canModifyProduct(user as never, "seller-1")).toBe(false);
+	});
+
+	it("returns false when user is null", () => {
+		expect(canModifyProduct(null, "seller-1")).toBe(false);
+	});
+});
+
+describe("isActionDisabled", () => {
+	describe("edit action", () => {
+		it("returns false when canEditOrDelete is true and not pending", () => {
+			expect(isActionDisabled("edit", true, false, false)).toBe(false);
+		});
+
+		it("returns true when canEditOrDelete is false", () => {
+			expect(isActionDisabled("edit", false, false, false)).toBe(true);
+		});
+
+		it("returns true when isPending is true", () => {
+			expect(isActionDisabled("edit", true, true, false)).toBe(true);
+		});
+	});
+
+	describe("delete action", () => {
+		it("returns false when canEditOrDelete is true and not pending", () => {
+			expect(isActionDisabled("delete", true, false, false)).toBe(false);
+		});
+
+		it("returns true when canEditOrDelete is false", () => {
+			expect(isActionDisabled("delete", false, false, false)).toBe(true);
+		});
+
+		it("returns true when isPending is true", () => {
+			expect(isActionDisabled("delete", true, true, false)).toBe(true);
+		});
+	});
+
+	describe("approve action", () => {
+		it("returns false when not approved and not pending", () => {
+			expect(isActionDisabled("approve", true, false, false)).toBe(false);
+		});
+
+		it("returns true when isApproved is true", () => {
+			expect(isActionDisabled("approve", true, false, true)).toBe(true);
+		});
+
+		it("returns true when isPending is true", () => {
+			expect(isActionDisabled("approve", true, true, false)).toBe(true);
+		});
+	});
+
+	describe("decline action", () => {
+		it("returns false when not approved and not pending", () => {
+			expect(isActionDisabled("decline", true, false, false)).toBe(false);
+		});
+
+		it("returns true when isApproved is true", () => {
+			expect(isActionDisabled("decline", true, false, true)).toBe(true);
+		});
+
+		it("returns true when isPending is true", () => {
+			expect(isActionDisabled("decline", true, true, false)).toBe(true);
+		});
+	});
+
+	describe("unknown action", () => {
+		it("returns false for unknown actions", () => {
+			expect(isActionDisabled("unknown", true, true, true)).toBe(false);
+		});
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [tsconfigPaths()],
+	test: {
+		include: ["src/**/*.test.{ts,tsx}"],
+		exclude: ["src/**/*.browser.test.{ts,tsx}"],
+		environment: "jsdom",
+		setupFiles: ["src/test/vitest.setup.ts"],
+	},
+});


### PR DESCRIPTION
## What issue does this close?

Closes #82

## Describe what changes were introduced in this pull request

Adds Vitest unit test configuration (jsdom environment) alongside existing browser tests for testing pure functions without browser overhead.

| File | Purpose |
|------|---------|
| `vitest.config.ts` | Standalone jsdom config |
| `src/test/vitest.setup.ts` | Minimal setup with afterEach cleanup |
| `src/utils/canModifyProduct.test.ts` | Example unit tests (18 tests) |
| `package.json` | Added `test:unit` script |

## Local testing

- [x] Run `bun run test:unit` - 18 tests pass
- [x] Run `bun run test:browser` - browser tests still work independently
- [x] Run `bun run check` on new files - no lint errors