### PR TITLE
ref: harden product image upload pipeline

### DIFF
--- a/src/actions/product.test.ts
+++ b/src/actions/product.test.ts
@@ -202,6 +202,18 @@ describe("product actions", () => {
 		expect(cloudinaryMock.deleteImage).toHaveBeenCalledWith("img-1");
 	});
 
+	it("rejects create when role is not authorized", async () => {
+		const payload = createValidPayload([makeImage("img-1.jpg")]);
+
+		const result = await createProductService("seller-1", "CUSTOMER", payload);
+
+		expect(result).toMatchObject({
+			error: "Unauthorized, user must be a seller",
+		});
+		expect(productRepoMock.createProduct).not.toHaveBeenCalled();
+		expect(cloudinaryMock.unsignedUploadImage).not.toHaveBeenCalled();
+	});
+
 	it("rejects invalid create payload before uploading", async () => {
 		const payload = createValidPayload([]);
 


### PR DESCRIPTION
## Summary
- Add bounded parallel image upload handling (`MAX_PRODUCT_IMAGE_UPLOADS = 3`) and centralized upload pipeline in `src/actions/product.ts`.
- Add best-effort cleanup of successfully uploaded images when partial create/update uploads fail.
- Expand `src/actions/product.test.ts` with realistic coverage for:
  - upload concurrency,
  - partial failure rollback,
  - cleanup failure behavior,
  - invalid payload short-circuiting,
  - missing-product update path,
  - unauthorized create-role gate.

## Testing
- `bun run lint`
- `bun test src/actions/product.test.ts`

## Linked Issue
Closes #147
