### PR TITLE
Improve navbar menu loading and query state handling

### DIFF
--- a/src/components/app-dropdown.tsx
+++ b/src/components/app-dropdown.tsx
@@ -10,6 +10,10 @@ interface AppDropdownProps {
 	children: React.ReactNode;
 	align?: "start" | "center" | "end";
 	className?: string;
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	onTriggerPointerEnter?: () => void;
+	onTriggerFocus?: () => void;
 }
 
 export function AppDropdown({
@@ -17,10 +21,20 @@ export function AppDropdown({
 	children,
 	align = "end",
 	className,
+	open,
+	onOpenChange,
+	onTriggerPointerEnter,
+	onTriggerFocus,
 }: AppDropdownProps) {
 	return (
-		<Popover>
-			<PopoverTrigger className="cursor-pointer">{trigger}</PopoverTrigger>
+		<Popover open={open} onOpenChange={onOpenChange}>
+			<PopoverTrigger
+				className="cursor-pointer"
+				onPointerEnter={onTriggerPointerEnter}
+				onFocus={onTriggerFocus}
+			>
+				{trigger}
+			</PopoverTrigger>
 			<PopoverContent align={align} className={cn(className)}>
 				{children}
 			</PopoverContent>

--- a/src/components/notification-list.tsx
+++ b/src/components/notification-list.tsx
@@ -1,4 +1,3 @@
-import type { UseMutateFunction } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { cva } from "class-variance-authority";
 import { Bell, Package, ShoppingBag } from "lucide-react";
@@ -41,7 +40,7 @@ interface NotificationListProps {
 	unreadCount: number;
 	isLoading: boolean;
 	isEmptyNotifications: boolean;
-	markAsRead: UseMutateFunction<NotificationData, Error, string, void>;
+	markAsRead: (id: string) => void;
 }
 
 const NotificationList = ({

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -1,23 +1,45 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ClientOnly } from "@tanstack/react-router";
 import { Bell, Package, PackageSearch, ShoppingCart } from "lucide-react";
+import { lazy, Suspense, useCallback, useMemo, useState } from "react";
 import { AppDropdown } from "@/components/app-dropdown";
 import Avatar from "@/components/avatar";
-import CartList from "@/components/cart-list";
 import NavbarIconButtons from "@/components/navbar-icon-buttons";
-import NotificationList from "@/components/notification-list";
-import OrderList from "@/components/order-list";
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAuthUser } from "@/hooks/use-auth-user";
-import useCartDetails from "@/hooks/use-cart-details";
-import useGetOrders from "@/hooks/use-get-orders";
-import useGetPendingProducts from "@/hooks/use-get-pending-products";
-import useNotifications from "@/hooks/use-notifications";
+import {
+	cartDetailsQueryOpt,
+	default as useCartDetails,
+} from "@/hooks/use-cart-details";
+import {
+	ordersByRoleQueryOpt,
+	default as useGetOrders,
+} from "@/hooks/use-get-orders";
+import {
+	pendingProductsQueryOpt,
+	default as useGetPendingProducts,
+} from "@/hooks/use-get-pending-products";
+import { productCountByStatusQueryOpt } from "@/hooks/use-get-products";
+import useNotifications, {
+	notificationCountQueryOpt,
+	notificationsQueryOpt,
+} from "@/hooks/use-notifications";
 import { useSignOut } from "@/hooks/use-sign-out";
+import { useCartStore } from "@/store/cart";
 import { useDialogStore } from "@/store/dialog";
 import type { UserRole } from "@/types/enum";
-import PendingProductList from "./pending-product-list";
+
+const loadCartList = () => import("@/components/cart-list");
+const loadOrderList = () => import("@/components/order-list");
+const loadNotificationList = () => import("@/components/notification-list");
+const loadPendingProductList = () => import("./pending-product-list");
+
+const CartList = lazy(loadCartList);
+const OrderList = lazy(loadOrderList);
+const NotificationList = lazy(loadNotificationList);
+const PendingProductList = lazy(loadPendingProductList);
 
 const UserMenuFallback = () => (
 	<div className="flex items-center gap-4" aria-hidden>
@@ -28,14 +50,46 @@ const UserMenuFallback = () => (
 	</div>
 );
 
+const DropdownContentFallback = () => (
+	<div className="w-80 p-4 space-y-3">
+		<Skeleton className="h-4 w-32" />
+		<Skeleton className="h-16 w-full" />
+		<Skeleton className="h-16 w-full" />
+		<Skeleton className="h-9 w-full" />
+	</div>
+);
+
 const CustomerActions = () => {
+	const queryClient = useQueryClient();
+	const [isOpen, setIsOpen] = useState(false);
+	const cartItems = useCartStore((state) => state.items);
+
+	const cartCount = useMemo(
+		() => cartItems.reduce((total, item) => total + item.quantity, 0),
+		[cartItems],
+	);
+
+	const uniqueProductIds = useMemo(
+		() => Array.from(new Set(cartItems.map((item) => item.productId))).sort(),
+		[cartItems],
+	);
+
 	const {
 		isCartEmpty,
 		isLoading: isCartLoading,
 		totalPrice,
-		cartCount,
 		cartWithDetails,
-	} = useCartDetails();
+	} = useCartDetails({ enabled: isOpen });
+
+	const prefetchCart = useCallback(() => {
+		void loadCartList();
+
+		if (uniqueProductIds.length === 0) {
+			return;
+		}
+
+		void queryClient.prefetchQuery(cartDetailsQueryOpt(uniqueProductIds));
+	}, [queryClient, uniqueProductIds]);
 
 	return (
 		<AppDropdown
@@ -46,26 +100,42 @@ const CustomerActions = () => {
 					ariaLabel="Shopping cart"
 				/>
 			}
+			open={isOpen}
+			onOpenChange={setIsOpen}
+			onTriggerPointerEnter={prefetchCart}
+			onTriggerFocus={prefetchCart}
 			align="end"
 		>
-			<CartList
-				isLoading={isCartLoading}
-				isCartEmpty={isCartEmpty}
-				totalPrice={totalPrice}
-				cartCount={cartCount}
-				cartWithDetails={cartWithDetails}
-			/>
+			{isOpen ? (
+				<Suspense fallback={<DropdownContentFallback />}>
+					<CartList
+						isLoading={isCartLoading}
+						isCartEmpty={isCartEmpty}
+						totalPrice={totalPrice}
+						cartCount={cartCount}
+						cartWithDetails={cartWithDetails}
+					/>
+				</Suspense>
+			) : null}
 		</AppDropdown>
 	);
 };
 
 const SellerActions = () => {
+	const queryClient = useQueryClient();
+	const [isOpen, setIsOpen] = useState(false);
+
 	const {
 		orders,
 		orderCount,
 		isLoading: isLoadingOrders,
 		isEmptyOrders,
-	} = useGetOrders("SELLER");
+	} = useGetOrders("SELLER", { enabled: true, polling: true });
+
+	const prefetchOrders = useCallback(() => {
+		void loadOrderList();
+		void queryClient.prefetchQuery(ordersByRoleQueryOpt("SELLER"));
+	}, [queryClient]);
 
 	return (
 		<AppDropdown
@@ -76,43 +146,72 @@ const SellerActions = () => {
 					ariaLabel="Orders"
 				/>
 			}
+			open={isOpen}
+			onOpenChange={setIsOpen}
+			onTriggerPointerEnter={prefetchOrders}
+			onTriggerFocus={prefetchOrders}
 			align="end"
 		>
-			<OrderList
-				orders={orders}
-				isLoading={isLoadingOrders}
-				isEmptyOrders={isEmptyOrders}
-				userRole="SELLER"
-			/>
+			{isOpen ? (
+				<Suspense fallback={<DropdownContentFallback />}>
+					<OrderList
+						orders={orders}
+						isLoading={isLoadingOrders}
+						isEmptyOrders={isEmptyOrders}
+						userRole="SELLER"
+					/>
+				</Suspense>
+			) : null}
 		</AppDropdown>
 	);
 };
 
 const AdminActions = () => {
-	const {
-		pendingProducts,
-		pendingProductCount,
-		isLoadingPendingProducts,
-		isEmptyPendingProducts,
-	} = useGetPendingProducts();
+	const queryClient = useQueryClient();
+	const [isOpen, setIsOpen] = useState(false);
+
+	const { data: pendingProductCountData } = useQuery(
+		productCountByStatusQueryOpt("pending"),
+	);
+	const pendingCount =
+		pendingProductCountData && "pendingProductCount" in pendingProductCountData
+			? pendingProductCountData.pendingProductCount
+			: 0;
+
+	const { pendingProducts, isLoadingPendingProducts, isEmptyPendingProducts } =
+		useGetPendingProducts({ enabled: isOpen });
+
+	const prefetchPendingProducts = useCallback(() => {
+		void loadPendingProductList();
+		void queryClient.prefetchQuery(productCountByStatusQueryOpt("pending"));
+		void queryClient.prefetchQuery(pendingProductsQueryOpt);
+	}, [queryClient]);
 
 	return (
 		<AppDropdown
 			trigger={
 				<NavbarIconButtons
 					icon={PackageSearch}
-					count={pendingProductCount}
+					count={pendingCount}
 					ariaLabel="Pending Products"
 				/>
 			}
+			open={isOpen}
+			onOpenChange={setIsOpen}
+			onTriggerPointerEnter={prefetchPendingProducts}
+			onTriggerFocus={prefetchPendingProducts}
 			align="end"
 		>
-			<PendingProductList
-				pendingProducts={pendingProducts}
-				pendingProductCount={pendingProductCount}
-				isLoading={isLoadingPendingProducts}
-				isEmptyPendingProducts={isEmptyPendingProducts}
-			/>
+			{isOpen ? (
+				<Suspense fallback={<DropdownContentFallback />}>
+					<PendingProductList
+						pendingProducts={pendingProducts}
+						pendingProductCount={pendingCount}
+						isLoading={isLoadingPendingProducts}
+						isEmptyPendingProducts={isEmptyPendingProducts}
+					/>
+				</Suspense>
+			) : null}
 		</AppDropdown>
 	);
 };
@@ -131,13 +230,27 @@ const RoleActions = ({ role }: { role: UserRole }) => {
 };
 
 const NotificationsMenu = () => {
+	const queryClient = useQueryClient();
+	const [isOpen, setIsOpen] = useState(false);
+
+	const { data: notificationCountData } = useQuery({
+		...notificationCountQueryOpt,
+		refetchInterval: 60000,
+	});
+	const unreadCount = notificationCountData?.count ?? 0;
+
 	const {
 		notifications,
 		isLoading: isLoadingNotification,
-		unreadCount,
 		isEmptyNotifications,
 		markAsReadMutate,
-	} = useNotifications();
+	} = useNotifications({ enabled: isOpen, polling: isOpen });
+
+	const prefetchNotifications = useCallback(() => {
+		void loadNotificationList();
+		void queryClient.prefetchQuery(notificationCountQueryOpt);
+		void queryClient.prefetchQuery(notificationsQueryOpt);
+	}, [queryClient]);
 
 	return (
 		<AppDropdown
@@ -148,15 +261,23 @@ const NotificationsMenu = () => {
 					ariaLabel="Notifications"
 				/>
 			}
+			open={isOpen}
+			onOpenChange={setIsOpen}
+			onTriggerPointerEnter={prefetchNotifications}
+			onTriggerFocus={prefetchNotifications}
 			align="end"
 		>
-			<NotificationList
-				notifications={notifications}
-				unreadCount={unreadCount}
-				isLoading={isLoadingNotification}
-				isEmptyNotifications={isEmptyNotifications}
-				markAsRead={markAsReadMutate}
-			/>
+			{isOpen ? (
+				<Suspense fallback={<DropdownContentFallback />}>
+					<NotificationList
+						notifications={notifications}
+						unreadCount={unreadCount}
+						isLoading={isLoadingNotification}
+						isEmptyNotifications={isEmptyNotifications}
+						markAsRead={markAsReadMutate}
+					/>
+				</Suspense>
+			) : null}
 		</AppDropdown>
 	);
 };

--- a/src/hooks/use-cart-details.ts
+++ b/src/hooks/use-cart-details.ts
@@ -10,14 +10,20 @@ export const cartDetailsQueryOpt = (productIds: string[]) =>
 		staleTime: 1000 * 60 * 2,
 	});
 
-const useCartDetails = () => {
+interface UseCartDetailsOptions {
+	enabled?: boolean;
+}
+
+const useCartDetails = (options: UseCartDetailsOptions = {}) => {
 	const cartItems = useCartStore((state) => state.items);
 	const updateQuantity = useCartStore((state) => state.updateQuantity);
 	const removeItem = useCartStore((state) => state.removeItem);
+	const enabled = options.enabled ?? true;
 
 	const uniqueProductIds = Array.from(
 		new Set(cartItems.map((item) => item.productId)),
 	).sort();
+	const shouldFetchCartDetails = enabled && uniqueProductIds.length > 0;
 
 	const {
 		data: products = [],
@@ -25,7 +31,7 @@ const useCartDetails = () => {
 		isError: isErrorProducts,
 	} = useQuery({
 		...cartDetailsQueryOpt(uniqueProductIds),
-		enabled: uniqueProductIds.length > 0,
+		enabled: shouldFetchCartDetails,
 	});
 
 	const productsById = new Map(
@@ -38,13 +44,16 @@ const useCartDetails = () => {
 		return {
 			...cartItem,
 			product,
-			isLoading: isLoadingProducts && !product,
-			isError: !isLoadingProducts && (isErrorProducts || !product),
+			isLoading: shouldFetchCartDetails && isLoadingProducts && !product,
+			isError:
+				shouldFetchCartDetails &&
+				!isLoadingProducts &&
+				(isErrorProducts || !product),
 		};
 	});
 
 	const isCartEmpty = cartItems.length === 0;
-	const isLoading = isLoadingProducts;
+	const isLoading = shouldFetchCartDetails && isLoadingProducts;
 
 	const totalPrice = cartWithDetails.reduce((sum, item) => {
 		if (item.product) {

--- a/src/hooks/use-get-orders.ts
+++ b/src/hooks/use-get-orders.ts
@@ -1,50 +1,73 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import {
+	queryOptions,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { useAuthUser } from "@/hooks/use-auth-user";
 import {
 	getOrderByCustomer,
 	getOrderBySeller,
 	updateOrderStatus,
 } from "@/lib/tanstack-query/orders-queries";
-import { useOrderStore } from "@/store/order";
 import type { OrderStatus, UserRole } from "@/types/enum";
+import type { OrderResponse } from "@/types/order";
 
-const useGetOrders = (userRole: UserRole) => {
-	const queryClient = useQueryClient();
-	const orders = useOrderStore((state) => state.orders);
-	const orderCount = useOrderStore((state) => state.orderCount);
-	const setOrders = useOrderStore((state) => state.setOrders);
-	const updateOrderInStore = useOrderStore((state) => state.updateOrder);
-
-	const { data: user } = useAuthUser();
-
+export const ordersByRoleQueryOpt = (userRole: UserRole) => {
 	const queryFn =
 		userRole === "CUSTOMER" ? getOrderByCustomer : getOrderBySeller;
 
-	const { data, isLoading } = useQuery({
+	return queryOptions({
 		queryKey: ["orders", userRole],
 		queryFn,
 		staleTime: 30000,
-		refetchInterval: 60000,
-		enabled: user !== null,
+	});
+};
+
+interface UseGetOrdersOptions {
+	enabled?: boolean;
+	polling?: boolean;
+}
+
+const useGetOrders = (
+	userRole: UserRole,
+	options: UseGetOrdersOptions = {},
+) => {
+	const queryClient = useQueryClient();
+
+	const { data: user } = useAuthUser();
+	const enabled = options.enabled ?? true;
+	const polling = options.polling ?? true;
+	const isQueryEnabled = enabled && user !== null;
+	const queryKey = ["orders", userRole] as const;
+
+	const { data, isLoading } = useQuery({
+		...ordersByRoleQueryOpt(userRole),
+		refetchInterval: isQueryEnabled && polling ? 60000 : false,
+		enabled: isQueryEnabled,
 	});
 
-	useEffect(() => {
-		if (data && !("error" in data)) {
-			setOrders(data);
-		}
-	}, [data, setOrders]);
+	const orders = Array.isArray(data) ? data : [];
+	const orderCount = orders.length;
 
 	const updateStatusMutation = useMutation({
 		mutationFn: ({ id, status }: { id: string; status: OrderStatus }) =>
 			updateOrderStatus(id, status),
 		onMutate: async ({ id, status }) => {
-			const previousOrders = orders;
-			const orderToUpdate = orders.find((o) => o.id === id);
+			await queryClient.cancelQueries({ queryKey });
 
-			if (orderToUpdate) {
-				updateOrderInStore(id, { ...orderToUpdate, status });
-			}
+			const previousOrders =
+				queryClient.getQueryData<OrderResponse[]>(queryKey);
+
+			queryClient.setQueryData<OrderResponse[]>(queryKey, (currentOrders) => {
+				if (!currentOrders) {
+					return currentOrders;
+				}
+
+				return currentOrders.map((order) =>
+					order.id === id ? { ...order, status } : order,
+				);
+			});
 
 			return { previousOrders };
 		},
@@ -52,13 +75,13 @@ const useGetOrders = (userRole: UserRole) => {
 			console.error("Failed to update order status:", err);
 
 			if (context?.previousOrders) {
-				setOrders(context.previousOrders);
+				queryClient.setQueryData(queryKey, context.previousOrders);
 			}
 
-			queryClient.invalidateQueries({ queryKey: ["orders", userRole] });
+			queryClient.invalidateQueries({ queryKey });
 		},
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["orders", userRole] });
+			queryClient.invalidateQueries({ queryKey });
 		},
 	});
 

--- a/src/hooks/use-get-pending-products.ts
+++ b/src/hooks/use-get-pending-products.ts
@@ -1,41 +1,36 @@
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
 import { useAuthUser } from "@/hooks/use-auth-user";
 import { getPendingApprovalProducts } from "@/lib/tanstack-query/product-queries";
-import { usePendingProductStore } from "@/store/pending-product";
 import type { BaseProduct } from "@/types/product";
 
-const pendingProductsQueryOpt = queryOptions<BaseProduct[]>({
+export const pendingProductsQueryOpt = queryOptions<BaseProduct[]>({
 	queryKey: ["pendingProducts"],
 	queryFn: getPendingApprovalProducts,
 	retry: false,
+	staleTime: 30000,
 });
 
-const useGetPendingProducts = () => {
+interface UseGetPendingProductsOptions {
+	enabled?: boolean;
+}
+
+const useGetPendingProducts = (options: UseGetPendingProductsOptions = {}) => {
 	const queryClient = useQueryClient();
-	const pendingProducts = usePendingProductStore(
-		(state) => state.pendingProducts,
-	);
-	const pendingProductCount = usePendingProductStore(
-		(state) => state.pendingProductCount,
-	);
-	const setPendingProducts = usePendingProductStore(
-		(state) => state.setPendingProducts,
-	);
 	const { data: user } = useAuthUser();
 	const userRole = user?.role;
+	const enabled = options.enabled ?? true;
 
 	const {
 		data,
 		isLoading: isLoadingPendingProducts,
 		isError: isErrorPendingProducts,
-	} = useQuery({ ...pendingProductsQueryOpt, enabled: userRole === "ADMIN" });
+	} = useQuery({
+		...pendingProductsQueryOpt,
+		enabled: enabled && userRole === "ADMIN",
+	});
 
-	useEffect(() => {
-		if (data) {
-			setPendingProducts(data);
-		}
-	}, [data, setPendingProducts]);
+	const pendingProducts = data ?? [];
+	const pendingProductCount = pendingProducts.length;
 
 	const isEmptyPendingProducts = pendingProducts.length === 0;
 

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -4,15 +4,15 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { useEffect } from "react";
 import { useAuthUser } from "@/hooks/use-auth-user";
 import {
+	getNotificationCount,
 	getUserNotifications,
 	readAllNotifications,
 	readNotificationById,
 } from "@/lib/tanstack-query/notifications-queries";
-import { useNotificationStore } from "@/store/notifications";
 import { useToastStore } from "@/store/toast";
+import type { NotificationData } from "@/types/notification";
 
 export const notificationsQueryOpt = queryOptions({
 	queryKey: ["notifications"],
@@ -20,55 +20,148 @@ export const notificationsQueryOpt = queryOptions({
 	staleTime: 30000,
 });
 
-const useNotifications = () => {
+export const notificationCountQueryOpt = queryOptions({
+	queryKey: ["notifications", "count"],
+	queryFn: getNotificationCount,
+	staleTime: 30000,
+});
+
+interface UseNotificationsOptions {
+	enabled?: boolean;
+	polling?: boolean;
+}
+
+const useNotifications = (options: UseNotificationsOptions = {}) => {
 	const queryClient = useQueryClient();
-	const notifications = useNotificationStore((state) => state.notifications);
-	const unreadCount = useNotificationStore((state) => state.unreadCount);
-	const setNotifications = useNotificationStore(
-		(state) => state.setNotifications,
-	);
-	const markAllAsRead = useNotificationStore((state) => state.markAllAsRead);
-	const markAsReadInStore = useNotificationStore((state) => state.markAsRead);
 
 	const { data: user } = useAuthUser();
 	const { showToast } = useToastStore();
+	const enabled = options.enabled ?? true;
+	const polling = options.polling ?? true;
+	const isQueryEnabled = enabled && user !== null;
+	const notificationsKey = ["notifications"] as const;
+	const notificationCountKey = ["notifications", "count"] as const;
 
 	const { data, isLoading } = useQuery({
 		...notificationsQueryOpt,
-		refetchInterval: 60000,
-		enabled: user !== null,
+		refetchInterval: isQueryEnabled && polling ? 60000 : false,
+		enabled: isQueryEnabled,
 	});
 
-	useEffect(() => {
-		if (data) {
-			setNotifications(data);
-		}
-	}, [data, setNotifications]);
+	const notifications = data ?? [];
+	const unreadCount = notifications.filter(
+		(notification) => !notification.isRead,
+	).length;
 
 	const { mutate: markAsReadMutate } = useMutation({
 		mutationFn: readNotificationById,
-		onMutate: (id) => {
-			markAsReadInStore(id);
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({ queryKey: notificationsKey });
+			await queryClient.cancelQueries({ queryKey: notificationCountKey });
+
+			const previousNotifications =
+				queryClient.getQueryData<NotificationData[]>(notificationsKey);
+			const previousCount = queryClient.getQueryData<{ count: number }>(
+				notificationCountKey,
+			);
+			const targetNotification = previousNotifications?.find(
+				(notification) => notification.id === id,
+			);
+
+			queryClient.setQueryData<NotificationData[]>(
+				notificationsKey,
+				(currentNotifications) =>
+					currentNotifications?.map((notification) =>
+						notification.id === id
+							? { ...notification, isRead: true }
+							: notification,
+					) ?? currentNotifications,
+			);
+
+			queryClient.setQueryData<{ count: number }>(
+				notificationCountKey,
+				(current) => {
+					if (!current) {
+						return current;
+					}
+
+					if (!targetNotification || targetNotification.isRead) {
+						return current;
+					}
+
+					return { count: Math.max(0, current.count - 1) };
+				},
+			);
+
+			return { previousNotifications, previousCount };
 		},
-		onError: (err, _) => {
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: notificationCountKey });
+		},
+		onError: (err, _, context) => {
 			console.error("Failed to mark notification as read:", err);
 
-			queryClient.invalidateQueries({ queryKey: ["notifications"] });
+			if (context?.previousNotifications) {
+				queryClient.setQueryData(
+					notificationsKey,
+					context.previousNotifications,
+				);
+			}
+
+			if (context?.previousCount) {
+				queryClient.setQueryData(notificationCountKey, context.previousCount);
+			}
+
+			queryClient.invalidateQueries({ queryKey: notificationsKey });
+			queryClient.invalidateQueries({ queryKey: notificationCountKey });
 		},
 	});
 
 	const { mutate: markAllAsReadMutate, isPending: isMarkingAllAsRead } =
 		useMutation({
 			mutationFn: readAllNotifications,
-			onMutate: () => {
-				markAllAsRead();
+			onMutate: async () => {
+				await queryClient.cancelQueries({ queryKey: notificationsKey });
+				await queryClient.cancelQueries({ queryKey: notificationCountKey });
+
+				const previousNotifications =
+					queryClient.getQueryData<NotificationData[]>(notificationsKey);
+				const previousCount = queryClient.getQueryData<{ count: number }>(
+					notificationCountKey,
+				);
+
+				queryClient.setQueryData<NotificationData[]>(
+					notificationsKey,
+					(currentNotifications) =>
+						currentNotifications?.map((notification) => ({
+							...notification,
+							isRead: true,
+						})) ?? currentNotifications,
+				);
+
+				queryClient.setQueryData(notificationCountKey, { count: 0 });
+
+				return { previousNotifications, previousCount };
 			},
 			onSuccess: () => {
-				queryClient.invalidateQueries({ queryKey: ["notifications"] });
+				queryClient.invalidateQueries({ queryKey: notificationsKey });
+				queryClient.invalidateQueries({ queryKey: notificationCountKey });
 			},
-			onError: () => {
+			onError: (_, __, context) => {
+				if (context?.previousNotifications) {
+					queryClient.setQueryData(
+						notificationsKey,
+						context.previousNotifications,
+					);
+				}
+
+				if (context?.previousCount) {
+					queryClient.setQueryData(notificationCountKey, context.previousCount);
+				}
+
 				showToast("Failed to mark all notifications as read", "error");
-				queryClient.invalidateQueries({ queryKey: ["notifications"] });
+				queryClient.invalidateQueries({ queryKey: notificationsKey });
+				queryClient.invalidateQueries({ queryKey: notificationCountKey });
 			},
 		});
 


### PR DESCRIPTION
## Summary
- lazy-load navbar dropdown content (cart, orders, notifications, pending approvals) and prefetch both code + query data on hover/focus
- gate heavy list queries behind dropdown open state while preserving live badge counts via lightweight count queries and seller order polling
- remove React Query -> Zustand mirroring for orders, pending products, and notifications; use query cache as source of truth with optimistic updates and rollback

## Related
- Closes #149

## Testing
- `bun run lint`
- `bun run test:unit` *(currently fails due pre-existing mock-hoist issue in `src/actions/product.test.ts`)*
- `bun run typecheck` *(currently blocked by existing tsconfig `--ignoreDeprecations` setting issue)*