### PR TITLE
chore: add optional feature capsule docs workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,3 +10,8 @@ if git diff --cached --name-only | grep -Eq '^AGENTS\.md$|^docs/'; then
   echo "Docs files changed. Running bun run docs:check..."
   bun run docs:check
 fi
+
+if git diff --cached --name-only | grep -Eq '^src/|^prisma/|^generated/|^public/|^package\.json$|^prisma\.config\.ts$|^vite\.config\.ts$|^tsconfig\.json$'; then
+  echo "Behavior-level files changed. Running bun run docs:report (non-blocking)..."
+  bun run docs:report || true
+fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 Load order: `AGENTS.md` -> `docs/README.md` -> `docs/agent-context-packs.md`
 
 - Packs: `docs/agent-context-packs.md`
+- Feature capsules: `docs/features/index.md`
 - Process: `docs/agent-documentation-pattern.md`
 - Integrity: `docs/docs-contradiction-checks.md`, `docs/concepts.map`, `bun run docs:check`
 - Runbook: `docs/runbooks/docs-health-checks.md`

--- a/docs/agent-context-packs.md
+++ b/docs/agent-context-packs.md
@@ -3,6 +3,7 @@
 
 ## Use first
 - `docs-process` → `docs/agent-documentation-pattern.md`, `docs/README.md`
+- `feature-capsules` → `docs/features/index.md`, `docs/features/features.map`
 - `theming` → `docs/theming.md`
 - `conventions` → `docs/commits.md`
 - `styling` → `docs/cva-classname-pattern.md`

--- a/docs/agent-documentation-pattern.md
+++ b/docs/agent-documentation-pattern.md
@@ -14,6 +14,7 @@
   - one concept per file
   - include file paths and command behavior where relevant
   - include `<!-- concept:def <id> -->` in canonical files
+  - exception: runtime feature capsules in `docs/features/*.md` do not require `concept:def` markers (framework files like `docs/features/index.md` and `docs/features/TEMPLATE.md` still do)
   - temporary/session handoff notes must live in `tmp/agent-notes/` and never in `docs/` (for example, avoid `*-next-session.md` under `docs/`)
 - Update flow:
   - add/update `docs/concepts.map`

--- a/docs/concepts.map
+++ b/docs/concepts.map
@@ -10,3 +10,5 @@ classnames_cva|docs/cva-classname-pattern.md|Classname composition with CVA and 
 docs_health_checks|docs/runbooks/docs-health-checks.md|Standard docs verification and pass criteria
 docs_gotchas|docs/gotchas/docs.md|Common docs pitfalls and quick fixes
 tanstack_auth_redirection|docs/runbooks/tanstack-start-auth-redirection.md|Auth redirect and route protection pattern for TanStack Start
+feature_capsules_index|docs/features/index.md|Entry point for optional feature capsule documentation
+feature_capsules_template|docs/features/TEMPLATE.md|Canonical template for feature capsule structure

--- a/docs/docs-contradiction-checks.md
+++ b/docs/docs-contradiction-checks.md
@@ -8,6 +8,7 @@ Goal:
 Mechanism:
 - `docs/concepts.map` lists canonical concept ownership.
 - Canonical docs include exactly one marker: `<!-- concept:def <id> -->`.
+- Exception: feature capsules under `docs/features/*.md` are allowed without concept-map registration, except canonical framework files (`docs/features/index.md`, `docs/features/TEMPLATE.md`).
 - `bun run docs:check` validates:
   - map entries exist and are tracked markdown files.
   - marker exists for each map concept.

--- a/docs/features/TEMPLATE.md
+++ b/docs/features/TEMPLATE.md
@@ -1,0 +1,50 @@
+# Feature Capsule Template
+<!-- concept:def feature_capsules_template -->
+
+Copy this template into a feature capsule file under `docs/features/` and update the registry entry in `docs/features/features.map`.
+
+Compactness rules (default):
+- Keep total length under 120 lines.
+- Keep each section to 3-6 bullets.
+- Prefer terse statements over narrative paragraphs.
+- Link file paths instead of re-explaining implementation details.
+
+```md
+# <Feature Name>
+<!-- feature:def <feature_id> -->
+
+---
+feature_id: <feature_id>
+owner_scope: <domain_or_team>
+tags:
+  - <tag_a>
+  - <tag_b>
+status: active
+last_reviewed: 2026-02-17
+---
+
+## Purpose
+- 1-2 bullets describing why this feature exists.
+
+## Behavior Contract
+- User-visible behavior guarantees.
+- Critical invariants and business rules.
+
+## Key Paths
+- `src/...`
+- `src/...`
+
+## Data Flow / Dependencies
+- Inputs:
+- Outputs:
+- Services/storage:
+
+## Change Log
+- 2026-02-17: Initial capsule.
+
+## Test Impact / Verification Notes
+- Relevant tests and manual verification summary.
+
+## Known Risks / Gotchas
+- Sharp edges and follow-up risks.
+```

--- a/docs/features/auth-session-route-guards.md
+++ b/docs/features/auth-session-route-guards.md
@@ -1,0 +1,55 @@
+# Auth Session and Route Guards
+<!-- feature:def auth_session_route_guards -->
+
+---
+feature_id: auth_session_route_guards
+owner_scope: shared
+tags:
+  - auth
+  - session
+  - rbac
+  - routing
+  - api
+status: active
+last_reviewed: 2026-02-17
+---
+
+## Purpose
+- Define the auth/session and RBAC baseline used by guarded routes and protected API handlers.
+
+## Behavior Contract
+- Sign-up and sign-in create a server session and store `userId` + `role`.
+- Sign-out clears the session.
+- Client route guards use `requireAuthUser` and `requireRole` and redirect unauthorized users to `/unauthorized`.
+- `requireAuthUser` checks cached auth user first, then fetches `/api/user` once with query key `["auth", "user"]`, no retries.
+- Server API handlers that need auth use `authMiddleware`; missing session or missing user returns `401`.
+- Role-only access can be enforced with `roleMiddleware(allowedRoles)` for server handlers.
+
+## Key Paths
+- `src/actions/auth.ts`
+- `src/utils/session.ts`
+- `src/middleware.ts`
+- `src/utils/require-role.ts`
+- `src/routes/api/auth.signin.ts`
+- `src/routes/api/auth.signup.ts`
+- `src/routes/api/auth.signout.ts`
+- `src/routes/api/user.ts`
+- `src/routes/cart.tsx`
+- `src/routes/checkout.tsx`
+
+## Data Flow / Dependencies
+- Inputs: credentials to auth API routes + session cookie (`auth`).
+- Outputs: auth payloads, `/unauthorized` redirects on guard failures, `401` for protected API without valid session.
+- Storage/deps: session via `useAppSession`, user lookup via `src/data/auth-repo.ts`.
+
+## Change Log
+- 2026-02-17: Initial capsule created to establish auth/session/RBAC behavior baseline.
+
+## Test Impact / Verification Notes
+- Coverage refs: `src/components/user-menu.browser.test.tsx`, `src/utils/can-modify-product.test.ts`.
+- Verify: unauthenticated access redirects to `/unauthorized`; protected API returns `401` without session; `CUSTOMER` can access `/cart` + `/checkout`.
+
+## Known Risks / Gotchas
+- Redirect target is currently `/unauthorized` rather than `/login` for client route guards.
+- `requireRole` depends on `["auth", "user"]` query state; stale client auth data can affect redirect timing.
+- Some RBAC checks also exist at action layer; keep route guard and server-side enforcement aligned.

--- a/docs/features/features.map
+++ b/docs/features/features.map
@@ -1,0 +1,9 @@
+# feature_id|canonical_path|tags|status|last_reviewed
+# tags use comma separation.
+# status values: active|legacy|deprecated
+
+# Auth and RBAC guards
+auth_session_route_guards|docs/features/auth-session-route-guards.md|auth,session,rbac,routing,api|active|2026-02-17
+
+# Example:
+# checkout_flow|docs/features/checkout-flow.md|checkout,payments,cart|active|2026-02-17

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -1,0 +1,24 @@
+# Feature Capsules
+<!-- concept:def feature_capsules_index -->
+
+Use feature capsules to capture behavior contracts and change context for important product areas.
+
+## Phase 1 policy
+- Capsule updates are optional and non-blocking.
+- Developers are not required to use an LLM.
+- Prefer short, high-signal updates over complete prose.
+
+## Retrieval model
+- Stage 1: read `docs/features/features.map` only.
+- Stage 2: load only matching capsule docs by tags and touched paths.
+- Stage 3: if no capsule exists, continue with code inspection and optionally add a capsule update.
+
+## Files
+- Registry: `docs/features/features.map`
+- Authoring template: `docs/features/TEMPLATE.md`
+
+## Quality baseline
+- One living capsule per feature area.
+- Keep a dated change log section in each capsule.
+- Update `last_reviewed` when changing capsule behavior notes.
+- Keep capsules compact: terse bullets, minimal prose, and only task-relevant paths.

--- a/docs/gotchas/docs.md
+++ b/docs/gotchas/docs.md
@@ -4,5 +4,6 @@
 - Concept marker must be exactly one and in canonical file.
 - `docs/concepts.map` parser assumes `id|path|note` format.
 - New concept docs are ignored by `docs:check` until map entry exists.
+- Feature capsules in `docs/features/*.md` are intentionally exempt from `concepts.map`, except framework files (`index.md`, `TEMPLATE.md`).
 - If you add docs in nested folders, verify workflow path glob does not exclude them.
 - Keep `AGENTS.md` short; deep details belong in `docs/`.

--- a/docs/runbooks/docs-health-checks.md
+++ b/docs/runbooks/docs-health-checks.md
@@ -4,6 +4,8 @@
 - Required for docs changes:
   - `bun run hooks:install` (once per machine) so pre-commit checks run.
   - `bun run docs:check` for every docs edit.
+  - `bun run docs:report` for optional feature capsule coverage reporting on behavior-level changes (non-blocking).
+  - if changing coverage report logic, run `bun run test:docs:report`.
   - edited concepts must exist in `docs/concepts.map`.
   - canonical docs must include `<!-- concept:def <id> -->`.
   - temporary/session handoff notes belong in `tmp/agent-notes/`, not `docs/` (avoid `*-next-session.md` under `docs/`).

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"test:unit": "vitest run --config vitest.config.ts",
 		"test:browser": "vitest run --config vitest.browser.config.ts",
 		"test:browser:headed": "vitest run --config vitest.browser.config.ts --browser.headless=false",
+		"test:docs:report": "node --test scripts/docs-coverage-report.test.cjs",
 		"format": "biome format",
 		"format:fix": "biome format --write",
 		"lint": "biome lint",
@@ -22,7 +23,9 @@
 		"typecheck": "tsc --noEmit",
 		"validate": "bun typecheck && bun lint",
 		"docs:check": "node scripts/docs-contradictions.cjs",
-		"docs:check:strict": "bun run docs:check"
+		"docs:check:strict": "bun run docs:check",
+		"docs:report": "node scripts/docs-coverage-report.cjs",
+		"docs:check:all": "bun run docs:check && bun run docs:report"
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.1.0",

--- a/scripts/docs-contradictions.cjs
+++ b/scripts/docs-contradictions.cjs
@@ -7,11 +7,20 @@ const ROOT = process.cwd();
 const REGISTRY_PATH = path.join(ROOT, 'docs', 'concepts.map');
 const CONCEPT_ID_REGEX = /^[a-z0-9_]+$/;
 const CONCEPT_DEF_REGEX = /<!--\s*concept:def\s+([a-z0-9_]+)\s*-->/g;
+const FEATURE_CAPSULE_PREFIX = 'docs/features/';
+const FEATURE_CAPSULE_CANONICAL_DOCS = new Set([
+  'docs/features/index.md',
+  'docs/features/TEMPLATE.md',
+]);
 const FORBIDDEN_DOC_FILENAME_PATTERNS = [
   /-next-session\.md$/i,
   /-handoff\.md$/i,
   /-temp\.md$/i,
 ];
+
+const isDynamicFeatureCapsuleDoc = file =>
+  file.startsWith(FEATURE_CAPSULE_PREFIX) &&
+  !FEATURE_CAPSULE_CANONICAL_DOCS.has(file);
 
 const readRegistry = () => {
   let raw;
@@ -140,10 +149,12 @@ const main = () => {
   }
 
   const canonicalPaths = new Set(Array.from(concepts.values()).map(meta => meta.canonicalPath));
-  const untrackedDocs = trackedDocs.filter(file => !canonicalPaths.has(file));
+  const untrackedDocs = trackedDocs.filter(
+    file => !canonicalPaths.has(file) && !isDynamicFeatureCapsuleDoc(file)
+  );
   if (untrackedDocs.length > 0) {
     errors.push(
-      `[docs] untracked markdown files found (every docs/*.md must be registered in docs/concepts.map): ${untrackedDocs.join(', ')}`
+      `[docs] untracked markdown files found (every docs/*.md except docs/features/* capsules must be registered in docs/concepts.map): ${untrackedDocs.join(', ')}`
     );
   }
 

--- a/scripts/docs-coverage-report.cjs
+++ b/scripts/docs-coverage-report.cjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+
+const ROOT = process.cwd();
+const getFeatureMapPath = (cwd = ROOT) =>
+  path.join(cwd, 'docs', 'features', 'features.map');
+const getSignalsDir = (cwd = ROOT) =>
+  path.join(cwd, 'tmp', 'agent-notes', 'docs-signals');
+
+const BEHAVIOR_FILE_PATTERNS = [
+  /^src\//,
+  /^prisma\//,
+  /^generated\//,
+  /^public\//,
+  /^package\.json$/,
+  /^prisma\.config\.ts$/,
+  /^tsconfig\.json$/,
+  /^vite\.config\.ts$/,
+];
+
+const NON_BEHAVIOR_PREFIXES = [
+  'docs/',
+  'tmp/',
+  '.github/',
+  '.githooks/',
+  '.vscode/',
+  'dist/',
+  'node_modules/',
+];
+
+const TAG_RULES = [
+  { tag: 'auth', pattern: /(auth|login|signup|session|account|user)/i },
+  { tag: 'checkout', pattern: /(checkout|payment|order|invoice|purchase)/i },
+  { tag: 'cart', pattern: /(cart|basket)/i },
+  { tag: 'catalog', pattern: /(catalog|product|listing|search)/i },
+  { tag: 'admin', pattern: /(admin|dashboard|moderation)/i },
+  { tag: 'data', pattern: /(prisma|schema|migration|database|db)/i },
+  { tag: 'api', pattern: /(api|server|route|endpoint)/i },
+];
+
+const splitLines = value =>
+  (value || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean);
+
+const unique = values => Array.from(new Set(values));
+
+const run = (command, { cwd = ROOT } = {}) => {
+  try {
+    return execSync(command, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (_error) {
+    return null;
+  }
+};
+
+const parseFeatureMapContent = raw => {
+  const lines = splitLines(raw);
+  const entries = [];
+
+  for (const line of lines) {
+    if (line.startsWith('#')) {
+      continue;
+    }
+
+    const [id, canonicalPath, tagsRaw = '', status = 'active', lastReviewed = ''] =
+      line.split('|').map(part => part.trim());
+
+    if (!id || !canonicalPath) {
+      continue;
+    }
+
+    entries.push({
+      id,
+      canonicalPath,
+      status,
+      lastReviewed,
+      tags: tagsRaw
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(Boolean),
+    });
+  }
+
+  return entries;
+};
+
+const parseFeatureMap = ({
+  cwd = ROOT,
+  featureMapPath = getFeatureMapPath(cwd),
+  existsSync = fs.existsSync,
+  readFileSync = fs.readFileSync,
+} = {}) => {
+  if (!existsSync(featureMapPath)) {
+    return [];
+  }
+
+  const raw = readFileSync(featureMapPath, 'utf8');
+  return parseFeatureMapContent(raw);
+};
+
+const getChangedFiles = ({
+  exec = run,
+  env = process.env,
+  cwd = ROOT,
+} = {}) => {
+  const safeRun = command => splitLines(exec(command, { cwd }));
+  const untracked = safeRun('git ls-files --others --exclude-standard');
+  const staged = safeRun('git diff --cached --name-only --diff-filter=ACMR');
+
+  if (staged.length > 0) {
+    return {
+      source: 'staged (+ untracked)',
+      files: unique([...staged, ...untracked]),
+    };
+  }
+
+  const baseRef = env.DOCS_REPORT_BASE || env.GITHUB_BASE_REF;
+  if (baseRef) {
+    const qualifiedRef = baseRef.startsWith('origin/')
+      ? baseRef
+      : `origin/${baseRef}`;
+    const fromBase = safeRun(
+      `git diff --name-only --diff-filter=ACMR ${qualifiedRef}...HEAD`
+    );
+    if (fromBase.length > 0 || untracked.length > 0) {
+      return {
+        source: `${qualifiedRef}...HEAD (+ untracked)`,
+        files: unique([...fromBase, ...untracked]),
+      };
+    }
+  }
+
+  return {
+    source: 'HEAD working tree (+ untracked)',
+    files: unique([
+      ...safeRun('git diff --name-only --diff-filter=ACMR HEAD'),
+      ...untracked,
+    ]),
+  };
+};
+
+const isBehaviorFile = file => {
+  if (NON_BEHAVIOR_PREFIXES.some(prefix => file.startsWith(prefix))) {
+    return false;
+  }
+
+  return BEHAVIOR_FILE_PATTERNS.some(pattern => pattern.test(file));
+};
+
+const inferTagsForFile = file => {
+  const tags = new Set();
+  const normalized = file.toLowerCase();
+
+  for (const rule of TAG_RULES) {
+    if (rule.pattern.test(normalized)) {
+      tags.add(rule.tag);
+    }
+  }
+
+  const routeMatch = normalized.match(/^src\/routes\/([^/]+)/);
+  if (routeMatch && routeMatch[1]) {
+    tags.add(routeMatch[1].replace(/\.[a-z0-9]+$/i, ''));
+  }
+
+  if (normalized.startsWith('prisma/')) {
+    tags.add('data');
+  }
+
+  if (tags.size === 0) {
+    tags.add('app');
+  }
+
+  return Array.from(tags);
+};
+
+const inferTags = files => {
+  const tags = new Set();
+
+  for (const file of files) {
+    for (const tag of inferTagsForFile(file)) {
+      tags.add(tag);
+    }
+  }
+
+  return Array.from(tags);
+};
+
+const listSignalFiles = ({
+  cwd = ROOT,
+  signalsDir = getSignalsDir(cwd),
+  existsSync = fs.existsSync,
+  readdirSync = fs.readdirSync,
+} = {}) => {
+  if (!existsSync(signalsDir)) {
+    return [];
+  }
+
+  return readdirSync(signalsDir, { withFileTypes: true })
+    .filter(
+      entry =>
+        entry.isFile() &&
+        entry.name.endsWith('.md') &&
+        entry.name.toLowerCase() !== 'template.md'
+    )
+    .map(entry => entry.name)
+    .sort();
+};
+
+const analyzeCoverage = ({ files, capsules, signalFiles }) => {
+  const changedFiles = files ?? [];
+  const registeredCapsules = capsules ?? [];
+  const signals = signalFiles ?? [];
+
+  if (changedFiles.length === 0) {
+    return {
+      type: 'no_changes',
+      behaviorFiles: [],
+      inferredTags: [],
+      matches: [],
+      signalFiles: signals,
+      capsuleCount: registeredCapsules.length,
+    };
+  }
+
+  const behaviorFiles = changedFiles.filter(isBehaviorFile);
+  if (behaviorFiles.length === 0) {
+    return {
+      type: 'no_behavior_changes',
+      behaviorFiles,
+      inferredTags: [],
+      matches: [],
+      signalFiles: signals,
+      capsuleCount: registeredCapsules.length,
+    };
+  }
+
+  const inferredTags = inferTags(behaviorFiles);
+  const matches = registeredCapsules.filter(capsule => {
+    const hasTagOverlap = capsule.tags.some(tag => inferredTags.includes(tag));
+    const directEdit = changedFiles.includes(capsule.canonicalPath);
+    return hasTagOverlap || directEdit;
+  });
+
+  return {
+    type: 'behavior_changes',
+    behaviorFiles,
+    inferredTags,
+    matches,
+    signalFiles: signals,
+    capsuleCount: registeredCapsules.length,
+  };
+};
+
+const formatReportLines = ({ source, files, analysis }) => {
+  const lines = [];
+  lines.push(`change source: ${source}`);
+  lines.push(`changed files: ${files.length}`);
+
+  if (analysis.type === 'no_changes') {
+    lines.push('no local changes detected; nothing to report.');
+    return lines;
+  }
+
+  if (analysis.type === 'no_behavior_changes') {
+    lines.push('no likely behavior-level changes detected.');
+    return lines;
+  }
+
+  lines.push(`behavior-level files: ${analysis.behaviorFiles.length}`);
+  lines.push(
+    `inferred tags: ${analysis.inferredTags.length > 0 ? analysis.inferredTags.join(', ') : 'none'}`
+  );
+  lines.push(
+    `registered capsules: ${analysis.capsuleCount}, matching capsules: ${analysis.matches.length}`
+  );
+
+  if (analysis.matches.length > 0) {
+    lines.push(
+      `matched capsule ids: ${analysis.matches.map(match => match.id).join(', ')}`
+    );
+  } else {
+    lines.push(
+      'warning: no matching feature capsule found. Optional next step: add/update a capsule under docs/features/.'
+    );
+  }
+
+  if (analysis.signalFiles.length === 0) {
+    lines.push(
+      'optional: add a docs signal note in tmp/agent-notes/docs-signals/ for future automation context.'
+    );
+  } else {
+    lines.push(`signal notes available: ${analysis.signalFiles.length}`);
+  }
+
+  lines.push('report complete (non-blocking).');
+  return lines;
+};
+
+const runCoverageReport = ({
+  logger = console.log,
+  exec = run,
+  env = process.env,
+  cwd = ROOT,
+  parseFeatureMapFn = parseFeatureMap,
+  listSignalFilesFn = listSignalFiles,
+} = {}) => {
+  const { source, files } = getChangedFiles({ exec, env, cwd });
+  const capsules = parseFeatureMapFn({ cwd });
+  const signalFiles = listSignalFilesFn({ cwd });
+  const analysis = analyzeCoverage({ files, capsules, signalFiles });
+  const lines = formatReportLines({ source, files, analysis });
+
+  for (const line of lines) {
+    logger(`[docs:report] ${line}`);
+  }
+
+  return { source, files, capsules, signalFiles, analysis, lines };
+};
+
+const main = () => {
+  try {
+    runCoverageReport();
+    process.exit(0);
+  } catch (error) {
+    console.log(`[docs:report] warning: report execution error: ${error.message}`);
+    console.log('[docs:report] report remains non-blocking.');
+    process.exit(0);
+  }
+};
+
+module.exports = {
+  BEHAVIOR_FILE_PATTERNS,
+  NON_BEHAVIOR_PREFIXES,
+  TAG_RULES,
+  splitLines,
+  unique,
+  getFeatureMapPath,
+  getSignalsDir,
+  parseFeatureMapContent,
+  parseFeatureMap,
+  getChangedFiles,
+  isBehaviorFile,
+  inferTagsForFile,
+  inferTags,
+  listSignalFiles,
+  analyzeCoverage,
+  formatReportLines,
+  runCoverageReport,
+  main,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/docs-coverage-report.test.cjs
+++ b/scripts/docs-coverage-report.test.cjs
@@ -1,0 +1,168 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseFeatureMapContent,
+  analyzeCoverage,
+  runCoverageReport,
+} = require('./docs-coverage-report.cjs');
+
+const TEMP_REPO_PREFIX = 'docs-report-test-';
+
+const runCmd = (command, cwd) =>
+  execSync(command, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+
+const cleanupStaleFixtureRepos = () => {
+  const tmpDir = os.tmpdir();
+  const entries = fs.readdirSync(tmpDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(TEMP_REPO_PREFIX)) {
+      continue;
+    }
+
+    const repoPath = path.join(tmpDir, entry.name);
+    if (!fs.existsSync(path.join(repoPath, '.git'))) {
+      continue;
+    }
+
+    fs.rmSync(repoPath, { recursive: true, force: true });
+  }
+};
+
+cleanupStaleFixtureRepos();
+
+const writeRepoFile = (repoPath, relativePath, contents) => {
+  const absolutePath = path.join(repoPath, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, 'utf8');
+};
+
+const appendRepoFile = (repoPath, relativePath, contents) => {
+  const absolutePath = path.join(repoPath, relativePath);
+  fs.appendFileSync(absolutePath, contents, 'utf8');
+};
+
+const createFixtureRepo = () => {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), TEMP_REPO_PREFIX));
+
+  runCmd('git init', repoPath);
+  runCmd('git checkout -b main', repoPath);
+  runCmd('git config user.email "docs-report-tests@example.com"', repoPath);
+  runCmd('git config user.name "Docs Report Tests"', repoPath);
+
+  writeRepoFile(
+    repoPath,
+    'docs/features/features.map',
+    [
+      '# feature_id|canonical_path|tags|status|last_reviewed',
+      'auth_session_route_guards|docs/features/auth-session-route-guards.md|auth,session,rbac,routing,api|active|2026-02-17',
+      '',
+    ].join('\n')
+  );
+  writeRepoFile(
+    repoPath,
+    'docs/features/auth-session-route-guards.md',
+    '# Auth Session and Route Guards\n'
+  );
+  writeRepoFile(repoPath, 'src/routes/auth/login.tsx', 'export const x = 1;\n');
+  writeRepoFile(repoPath, 'docs/README.md', '# docs\n');
+
+  runCmd('git add .', repoPath);
+  runCmd('git commit -m "test fixture baseline"', repoPath);
+
+  return repoPath;
+};
+
+test('parseFeatureMapContent parses valid registry lines', () => {
+  const raw = `
+# comment
+auth_session_route_guards|docs/features/auth-session-route-guards.md|auth,session|active|2026-02-17
+bad_line_without_path|
+`;
+
+  const entries = parseFeatureMapContent(raw);
+
+  assert.equal(entries.length, 1);
+  assert.deepEqual(entries[0], {
+    id: 'auth_session_route_guards',
+    canonicalPath: 'docs/features/auth-session-route-guards.md',
+    status: 'active',
+    lastReviewed: '2026-02-17',
+    tags: ['auth', 'session'],
+  });
+});
+
+test('analyzeCoverage classifies behavior and non-behavior changes', () => {
+  const withBehavior = analyzeCoverage({
+    files: ['src/routes/auth/login.tsx'],
+    capsules: [
+      {
+        id: 'auth_session_route_guards',
+        canonicalPath: 'docs/features/auth-session-route-guards.md',
+        status: 'active',
+        lastReviewed: '2026-02-17',
+        tags: ['auth'],
+      },
+    ],
+    signalFiles: [],
+  });
+
+  assert.equal(withBehavior.type, 'behavior_changes');
+  assert.equal(withBehavior.matches.length, 1);
+
+  const docsOnly = analyzeCoverage({
+    files: ['docs/README.md'],
+    capsules: [],
+    signalFiles: [],
+  });
+
+  assert.equal(docsOnly.type, 'no_behavior_changes');
+});
+
+test('integration: staged auth route change matches real capsule mapping', t => {
+  const repoPath = createFixtureRepo();
+  t.after(() => fs.rmSync(repoPath, { recursive: true, force: true }));
+
+  appendRepoFile(repoPath, 'src/routes/auth/login.tsx', 'export const y = 2;\n');
+  writeRepoFile(
+    repoPath,
+    'tmp/agent-notes/docs-signals/auth-change.md',
+    '# auth-change\n'
+  );
+  runCmd('git add src/routes/auth/login.tsx', repoPath);
+
+  const result = runCoverageReport({
+    cwd: repoPath,
+    logger: () => {},
+  });
+
+  assert.equal(result.analysis.type, 'behavior_changes');
+  assert.equal(result.analysis.matches.length, 1);
+  assert.equal(result.analysis.matches[0].id, 'auth_session_route_guards');
+  assert.equal(result.analysis.signalFiles.length, 1);
+});
+
+test('integration: staged docs-only change remains non-behavioral', t => {
+  const repoPath = createFixtureRepo();
+  t.after(() => fs.rmSync(repoPath, { recursive: true, force: true }));
+
+  appendRepoFile(repoPath, 'docs/README.md', '\nextra docs note\n');
+  runCmd('git add docs/README.md', repoPath);
+
+  const result = runCoverageReport({
+    cwd: repoPath,
+    logger: () => {},
+  });
+
+  assert.equal(result.analysis.type, 'no_behavior_changes');
+  assert.equal(result.analysis.behaviorFiles.length, 0);
+});


### PR DESCRIPTION
## Summary
- backport the optional feature capsule docs workflow commit (`08b61b3`) into `main`
- add `docs/features/*` guidance and registry files for behavior-level feature documentation
- add docs coverage reporting scripts and tests, and wire docs checks into pre-commit/docs process

## Why
- this work was merged into a side branch lineage (`ref/navbar-query-gating`) but never reached `main`
- bringing it into `main` aligns docs structure with the intended feature capsule workflow

## Testing
- `bun run docs:check`
- `node --test scripts/docs-coverage-report.test.cjs`